### PR TITLE
use 0.6.0-pre as minimum julia version in REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 0.6-
+julia 0.6.0-pre


### PR DESCRIPTION
since `abstract type` syntax wouldn't work in early 0.6.0-dev versions,
better to stick to the julia-0.5-compatible versions of the package there